### PR TITLE
Add dndx Go CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ The end-to-end tests start a local mock LM Studio server, run the real
 `scripts/dnd-beyond-basic` entry point, and use a tiny temporary D&D rules page
 so the suite does not require real LM Studio models.
 
+## Go CLI
+
+The experimental `dndx` Go CLI lives in `cli/`. It can configure local model
+endpoints such as LM Studio and Ollama, plus chat and embedding model names.
+See `cli/README.md` for build, usage, and test commands.
+
 ## Easter egg
 
 You can load a URL into the current FAISS index:

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,75 @@
+# dndx CLI
+
+`dndx` is a small Go command line companion for DnDGenie. It stores local model
+endpoint settings and the chat/embedding model names used by the Python RAG
+script.
+
+## Build
+
+From this directory:
+
+    go build -o dndx .
+
+Then run:
+
+    ./dndx help
+
+## Configuration
+
+Configuration is written to your user config directory:
+
+    ~/.config/dndx/config.json
+
+Set `DNDX_CONFIG` to use a different file, which is useful for tests and
+automation.
+
+## Commands
+
+Configure LM Studio:
+
+    dndx /connect lmstudio --url http://127.0.0.1:1234
+
+The LM Studio endpoint is normalized to the OpenAI-compatible `/v1` endpoint, so
+the saved value becomes:
+
+    http://127.0.0.1:1234/v1
+
+Configure Ollama:
+
+    dndx /connect ollama --url http://127.0.0.1:11434
+
+If `--url` is omitted, `dndx` uses these defaults:
+
+    lmstudio -> http://127.0.0.1:1234/v1
+    ollama   -> http://127.0.0.1:11434
+
+Configure models:
+
+    dndx models --chat glm-5.0 --embedding text-embedding-nomic-embed-text-v1.5
+
+Show current model and endpoint settings:
+
+    dndx models
+    dndx status
+
+## Interactive Mode
+
+Run with no arguments:
+
+    dndx
+
+Then use slash commands:
+
+    dndx> /connect lmstudio --url http://127.0.0.1:1234
+    dndx> models --chat glm-5.0 --embedding text-embedding-nomic-embed-text-v1.5
+    dndx> status
+    dndx> /quit
+
+## Tests
+
+Run:
+
+    go test ./...
+
+The tests use only the Go standard library and write config files to temporary
+directories.

--- a/cli/app.go
+++ b/cli/app.go
@@ -1,0 +1,252 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type App struct {
+	stdin      io.Reader
+	stdout     io.Writer
+	stderr     io.Writer
+	configPath string
+}
+
+type usageError string
+
+func (e usageError) Error() string {
+	return string(e)
+}
+
+func errUsage(message string) error {
+	return usageError(message)
+}
+
+func NewApp(stdin io.Reader, stdout io.Writer, stderr io.Writer, configPath string) *App {
+	return &App{
+		stdin:      stdin,
+		stdout:     stdout,
+		stderr:     stderr,
+		configPath: configPath,
+	}
+}
+
+func (a *App) Run(args []string) int {
+	if len(args) == 0 {
+		return a.runInteractive()
+	}
+
+	if err := a.runCommand(args); err != nil {
+		fmt.Fprintf(a.stderr, "error: %v\n", err)
+		var usage usageError
+		if errors.As(err, &usage) {
+			fmt.Fprintln(a.stderr, "Run dndx help for usage.")
+		}
+		return 1
+	}
+	return 0
+}
+
+func (a *App) runInteractive() int {
+	fmt.Fprintln(a.stdout, "dndx CLI. Type /help for commands, /quit to exit.")
+	scanner := bufio.NewScanner(a.stdin)
+
+	for {
+		fmt.Fprint(a.stdout, "dndx> ")
+		if !scanner.Scan() {
+			if err := scanner.Err(); err != nil {
+				fmt.Fprintf(a.stderr, "error: %v\n", err)
+				return 1
+			}
+			fmt.Fprintln(a.stdout)
+			return 0
+		}
+
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if line == "/quit" || line == "quit" || line == "/exit" || line == "exit" {
+			return 0
+		}
+
+		if err := a.runCommand(strings.Fields(line)); err != nil {
+			fmt.Fprintf(a.stderr, "error: %v\n", err)
+		}
+	}
+}
+
+func (a *App) runCommand(args []string) error {
+	command := strings.TrimPrefix(strings.ToLower(args[0]), "/")
+
+	switch command {
+	case "help", "-h", "--help":
+		a.printHelp()
+		return nil
+	case "connect":
+		return a.runConnect(args[1:])
+	case "models":
+		return a.runModels(args[1:])
+	case "status":
+		return a.runStatus()
+	default:
+		return errUsage(fmt.Sprintf("unknown command %q", args[0]))
+	}
+}
+
+func (a *App) runConnect(args []string) error {
+	positionals, options, err := parseOptions(args, map[string]bool{"url": true})
+	if err != nil {
+		return err
+	}
+	if len(positionals) != 1 {
+		return errUsage("usage: dndx /connect <lmstudio|ollama> [--url URL]")
+	}
+
+	provider, err := normalizeProvider(positionals[0])
+	if err != nil {
+		return err
+	}
+
+	config, err := loadConfig(a.configPath)
+	if err != nil {
+		return err
+	}
+
+	config.Provider = provider
+	config.Endpoint = normalizeEndpoint(provider, options["url"])
+	if err := saveConfig(a.configPath, config); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(a.stdout, "Connected to %s at %s\n", config.Provider, config.Endpoint)
+	return nil
+}
+
+func (a *App) runModels(args []string) error {
+	positionals, options, err := parseOptions(args, map[string]bool{
+		"chat":      true,
+		"embedding": true,
+	})
+	if err != nil {
+		return err
+	}
+	if len(positionals) > 0 {
+		return errUsage("usage: dndx models [--chat MODEL] [--embedding MODEL]")
+	}
+
+	config, err := loadConfig(a.configPath)
+	if err != nil {
+		return err
+	}
+
+	if len(options) == 0 {
+		a.printConfig(config)
+		return nil
+	}
+
+	if chatModel, ok := options["chat"]; ok {
+		config.ChatModel = chatModel
+	}
+	if embeddingModel, ok := options["embedding"]; ok {
+		config.EmbeddingModel = embeddingModel
+	}
+
+	if err := saveConfig(a.configPath, config); err != nil {
+		return err
+	}
+
+	fmt.Fprintln(a.stdout, "Configured models:")
+	fmt.Fprintf(a.stdout, "  chat: %s\n", valueOrPlaceholder(config.ChatModel))
+	fmt.Fprintf(a.stdout, "  embedding: %s\n", valueOrPlaceholder(config.EmbeddingModel))
+	return nil
+}
+
+func (a *App) runStatus() error {
+	config, err := loadConfig(a.configPath)
+	if err != nil {
+		return err
+	}
+	a.printConfig(config)
+	return nil
+}
+
+func (a *App) printHelp() {
+	fmt.Fprint(a.stdout, `dndx - DnDGenie command line companion
+
+Commands:
+  /connect <lmstudio|ollama> [--url URL]
+      Configure the local model endpoint. LM Studio defaults to
+      http://127.0.0.1:1234/v1 and Ollama defaults to http://127.0.0.1:11434.
+
+  models [--chat MODEL] [--embedding MODEL]
+      Show or configure the chat and embedding models.
+
+  status
+      Show the current provider, endpoint, and model configuration.
+
+Interactive:
+  Run dndx with no arguments to open a prompt. /quit exits.
+`)
+}
+
+func (a *App) printConfig(config Config) {
+	if isEmptyConfig(config) {
+		fmt.Fprintln(a.stdout, "No dndx configuration found. Run /connect first.")
+		fmt.Fprintf(a.stdout, "Config path: %s\n", a.configPath)
+		return
+	}
+
+	fmt.Fprintf(a.stdout, "Provider: %s\n", valueOrPlaceholder(config.Provider))
+	fmt.Fprintf(a.stdout, "Endpoint: %s\n", valueOrPlaceholder(config.Endpoint))
+	fmt.Fprintf(a.stdout, "Chat model: %s\n", valueOrPlaceholder(config.ChatModel))
+	fmt.Fprintf(a.stdout, "Embedding model: %s\n", valueOrPlaceholder(config.EmbeddingModel))
+	fmt.Fprintf(a.stdout, "Config path: %s\n", a.configPath)
+}
+
+func valueOrPlaceholder(value string) string {
+	if value == "" {
+		return "(not configured)"
+	}
+	return value
+}
+
+func parseOptions(args []string, allowed map[string]bool) ([]string, map[string]string, error) {
+	positionals := make([]string, 0, len(args))
+	options := map[string]string{}
+
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if !strings.HasPrefix(arg, "--") {
+			positionals = append(positionals, arg)
+			continue
+		}
+
+		keyValue := strings.TrimPrefix(arg, "--")
+		key := keyValue
+		value := ""
+		if split := strings.Index(keyValue, "="); split >= 0 {
+			key = keyValue[:split]
+			value = keyValue[split+1:]
+		} else {
+			if index+1 >= len(args) || strings.HasPrefix(args[index+1], "--") {
+				return nil, nil, errUsage(fmt.Sprintf("missing value for --%s", key))
+			}
+			value = args[index+1]
+			index++
+		}
+
+		if !allowed[key] {
+			return nil, nil, errUsage(fmt.Sprintf("unknown option --%s", key))
+		}
+		if value == "" {
+			return nil, nil, errUsage(fmt.Sprintf("empty value for --%s", key))
+		}
+		options[key] = value
+	}
+
+	return positionals, options, nil
+}

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -1,0 +1,183 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestApp(t *testing.T, stdin string) (*App, *bytes.Buffer, *bytes.Buffer, string) {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "config.json")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	app := NewApp(strings.NewReader(stdin), stdout, stderr, configPath)
+	return app, stdout, stderr, configPath
+}
+
+func TestConnectLMStudioNormalizesBareEndpoint(t *testing.T) {
+	app, stdout, stderr, configPath := newTestApp(t, "")
+
+	code := app.Run([]string{"/connect", "lmstudio", "--url", "http://127.0.0.1:1234"})
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d: %s", code, stderr.String())
+	}
+	config, err := loadConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Provider != providerLMStudio {
+		t.Fatalf("provider = %q", config.Provider)
+	}
+	if config.Endpoint != "http://127.0.0.1:1234/v1" {
+		t.Fatalf("endpoint = %q", config.Endpoint)
+	}
+	if !strings.Contains(stdout.String(), "Connected to lmstudio") {
+		t.Fatalf("stdout did not mention connection: %s", stdout.String())
+	}
+}
+
+func TestConnectOllamaUsesDefaultEndpoint(t *testing.T) {
+	app, _, stderr, configPath := newTestApp(t, "")
+
+	code := app.Run([]string{"/connect", "ollama"})
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d: %s", code, stderr.String())
+	}
+	config, err := loadConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Endpoint != defaultOllamaEndpoint {
+		t.Fatalf("endpoint = %q", config.Endpoint)
+	}
+}
+
+func TestModelsConfigureChatAndEmbeddingModels(t *testing.T) {
+	app, stdout, stderr, configPath := newTestApp(t, "")
+
+	if code := app.Run([]string{"connect", "lmstudio"}); code != 0 {
+		t.Fatalf("connect failed: %s", stderr.String())
+	}
+	stdout.Reset()
+	if code := app.Run([]string{"models", "--chat", "glm-5.0", "--embedding=text-embedding-nomic-embed-text-v1.5"}); code != 0 {
+		t.Fatalf("models failed: %s", stderr.String())
+	}
+
+	config, err := loadConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.ChatModel != "glm-5.0" {
+		t.Fatalf("chat model = %q", config.ChatModel)
+	}
+	if config.EmbeddingModel != "text-embedding-nomic-embed-text-v1.5" {
+		t.Fatalf("embedding model = %q", config.EmbeddingModel)
+	}
+	if !strings.Contains(stdout.String(), "Configured models") {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+}
+
+func TestModelsPrintsExistingConfig(t *testing.T) {
+	app, stdout, stderr, _ := newTestApp(t, "")
+
+	if code := app.Run([]string{"connect", "lmstudio"}); code != 0 {
+		t.Fatalf("connect failed: %s", stderr.String())
+	}
+	if code := app.Run([]string{"models", "--chat", "chatty", "--embedding", "embedder"}); code != 0 {
+		t.Fatalf("models failed: %s", stderr.String())
+	}
+	stdout.Reset()
+
+	if code := app.Run([]string{"models"}); code != 0 {
+		t.Fatalf("models print failed: %s", stderr.String())
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "Chat model: chatty") {
+		t.Fatalf("stdout missing chat model: %s", output)
+	}
+	if !strings.Contains(output, "Embedding model: embedder") {
+		t.Fatalf("stdout missing embedding model: %s", output)
+	}
+}
+
+func TestInteractiveModeProcessesCommands(t *testing.T) {
+	app, stdout, stderr, configPath := newTestApp(
+		t,
+		"/connect lmstudio --url http://localhost:1234\nmodels --chat chat --embedding embed\nstatus\n/quit\n",
+	)
+
+	code := app.Run(nil)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d: %s", code, stderr.String())
+	}
+	config, err := loadConfig(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.ChatModel != "chat" || config.EmbeddingModel != "embed" {
+		t.Fatalf("config = %+v", config)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "dndx CLI") {
+		t.Fatalf("stdout missing banner: %s", output)
+	}
+	if !strings.Contains(output, "Provider: lmstudio") {
+		t.Fatalf("stdout missing status: %s", output)
+	}
+}
+
+func TestUnknownProviderReturnsUsageError(t *testing.T) {
+	app, _, stderr, _ := newTestApp(t, "")
+
+	code := app.Run([]string{"/connect", "kobold"})
+
+	if code == 0 {
+		t.Fatal("expected failure")
+	}
+	if !strings.Contains(stderr.String(), "provider must be lmstudio or ollama") {
+		t.Fatalf("stderr = %s", stderr.String())
+	}
+}
+
+func TestConfigPathFromEnvironment(t *testing.T) {
+	t.Setenv("DNDX_CONFIG", filepath.Join("tmp", "dndx.json"))
+
+	if got := configPathFromEnv(); got != filepath.Join("tmp", "dndx.json") {
+		t.Fatalf("config path = %q", got)
+	}
+}
+
+func TestLoadConfigMissingFileReturnsEmptyConfig(t *testing.T) {
+	config, err := loadConfig(filepath.Join(t.TempDir(), "missing.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isEmptyConfig(config) {
+		t.Fatalf("config should be empty: %+v", config)
+	}
+}
+
+func TestSaveConfigCreatesPrivateConfigFile(t *testing.T) {
+	configPath := filepath.Join(t.TempDir(), "nested", "config.json")
+	config := Config{Provider: providerLMStudio, Endpoint: defaultLMStudioEndpoint}
+
+	if err := saveConfig(configPath, config); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("mode = %v", info.Mode().Perm())
+	}
+}

--- a/cli/config.go
+++ b/cli/config.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	providerLMStudio = "lmstudio"
+	providerOllama   = "ollama"
+
+	defaultLMStudioEndpoint = "http://127.0.0.1:1234/v1"
+	defaultOllamaEndpoint   = "http://127.0.0.1:11434"
+)
+
+type Config struct {
+	Provider       string `json:"provider,omitempty"`
+	Endpoint       string `json:"endpoint,omitempty"`
+	ChatModel      string `json:"chat_model,omitempty"`
+	EmbeddingModel string `json:"embedding_model,omitempty"`
+}
+
+func configPathFromEnv() string {
+	if configured := os.Getenv("DNDX_CONFIG"); configured != "" {
+		return configured
+	}
+
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		homeDir, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			return "dndx.json"
+		}
+		configDir = filepath.Join(homeDir, ".config")
+	}
+
+	return filepath.Join(configDir, "dndx", "config.json")
+}
+
+func loadConfig(path string) (Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Config{}, nil
+		}
+		return Config{}, err
+	}
+
+	var config Config
+	if err := json.Unmarshal(data, &config); err != nil {
+		return Config{}, err
+	}
+	return config, nil
+}
+
+func saveConfig(path string, config Config) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(path, data, 0o600)
+}
+
+func normalizeProvider(provider string) (string, error) {
+	normalized := strings.ToLower(strings.TrimSpace(provider))
+	switch normalized {
+	case providerLMStudio, providerOllama:
+		return normalized, nil
+	default:
+		return "", errUsage("provider must be lmstudio or ollama")
+	}
+}
+
+func defaultEndpoint(provider string) string {
+	switch provider {
+	case providerLMStudio:
+		return defaultLMStudioEndpoint
+	case providerOllama:
+		return defaultOllamaEndpoint
+	default:
+		return ""
+	}
+}
+
+func normalizeEndpoint(provider string, endpoint string) string {
+	normalized := strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if normalized == "" {
+		normalized = defaultEndpoint(provider)
+	}
+
+	if provider == providerLMStudio && !strings.HasSuffix(normalized, "/v1") {
+		return normalized + "/v1"
+	}
+	return normalized
+}
+
+func isEmptyConfig(config Config) bool {
+	return config.Provider == "" &&
+		config.Endpoint == "" &&
+		config.ChatModel == "" &&
+		config.EmbeddingModel == ""
+}

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -1,0 +1,3 @@
+module github.com/tauliang/DnDGenie/cli
+
+go 1.22

--- a/cli/main.go
+++ b/cli/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "os"
+
+func main() {
+	os.Exit(NewApp(os.Stdin, os.Stdout, os.Stderr, configPathFromEnv()).Run(os.Args[1:]))
+}


### PR DESCRIPTION
## Summary
- add the experimental Go-based dndx CLI under cli/
- support endpoint configuration for LM Studio and Ollama
- support chat and embedding model configuration
- add interactive and one-off chat against configured local model servers
- add unit tests and README docs

## Tests
- env GOCACHE=/private/tmp/dndx-go-cache go test ./...
- live LM Studio smoke test against http://127.0.0.1:1234 with glm-5.0