### PR TITLE
Add dndx chat mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,9 @@ so the suite does not require real LM Studio models.
 ## Go CLI
 
 The experimental `dndx` Go CLI lives in `cli/`. It can configure local model
-endpoints such as LM Studio and Ollama, plus chat and embedding model names.
-See `cli/README.md` for build, usage, and test commands.
+endpoints such as LM Studio and Ollama, configure chat and embedding model
+names, and chat with the configured local model. See `cli/README.md` for build,
+usage, and test commands.
 
 ## Easter egg
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,8 +1,8 @@
 # dndx CLI
 
 `dndx` is a small Go command line companion for DnDGenie. It stores local model
-endpoint settings and the chat/embedding model names used by the Python RAG
-script.
+endpoint settings, configures chat/embedding model names, and can chat with a
+local model server.
 
 ## Build
 
@@ -52,18 +52,29 @@ Show current model and endpoint settings:
     dndx models
     dndx status
 
+Ask a one-off question:
+
+    dndx chat provide a brief random encounter table for 3 first-level characters. They are in the woods.
+
 ## Interactive Mode
 
 Run with no arguments:
 
     dndx
 
-Then use slash commands:
+Then type plain text at the `_` prompt to chat:
 
-    dndx> /connect lmstudio --url http://127.0.0.1:1234
-    dndx> models --chat glm-5.0 --embedding text-embedding-nomic-embed-text-v1.5
-    dndx> status
-    dndx> /quit
+    dndx _ provide a brief random encounter table for 3 first-level characters. They are in the woods.
+
+Slash commands are handled locally:
+
+    dndx _ /connect lmstudio --url http://127.0.0.1:1234
+    dndx _ models --chat glm-5.0 --embedding text-embedding-nomic-embed-text-v1.5
+    dndx _ status
+    dndx _ /quit
+
+LM Studio uses its OpenAI-compatible `/v1/chat/completions` endpoint. Ollama
+uses its native `/api/chat` endpoint.
 
 ## Tests
 

--- a/cli/app.go
+++ b/cli/app.go
@@ -2,17 +2,23 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"strings"
+	"time"
 )
 
+const interactivePrompt = "dndx _ "
+
 type App struct {
-	stdin      io.Reader
-	stdout     io.Writer
-	stderr     io.Writer
-	configPath string
+	stdin       io.Reader
+	stdout      io.Writer
+	stderr      io.Writer
+	configPath  string
+	chatFactory chatClientFactory
+	chatHistory []chatMessage
 }
 
 type usageError string
@@ -27,10 +33,11 @@ func errUsage(message string) error {
 
 func NewApp(stdin io.Reader, stdout io.Writer, stderr io.Writer, configPath string) *App {
 	return &App{
-		stdin:      stdin,
-		stdout:     stdout,
-		stderr:     stderr,
-		configPath: configPath,
+		stdin:       stdin,
+		stdout:      stdout,
+		stderr:      stderr,
+		configPath:  configPath,
+		chatFactory: newChatClient,
 	}
 }
 
@@ -51,11 +58,11 @@ func (a *App) Run(args []string) int {
 }
 
 func (a *App) runInteractive() int {
-	fmt.Fprintln(a.stdout, "dndx CLI. Type /help for commands, /quit to exit.")
+	fmt.Fprintln(a.stdout, "dndx chat. Type a message, /help for commands, /quit to exit.")
 	scanner := bufio.NewScanner(a.stdin)
 
 	for {
-		fmt.Fprint(a.stdout, "dndx> ")
+		fmt.Fprint(a.stdout, interactivePrompt)
 		if !scanner.Scan() {
 			if err := scanner.Err(); err != nil {
 				fmt.Fprintf(a.stderr, "error: %v\n", err)
@@ -73,10 +80,21 @@ func (a *App) runInteractive() int {
 			return 0
 		}
 
-		if err := a.runCommand(strings.Fields(line)); err != nil {
+		if err := a.runInteractiveLine(line); err != nil {
 			fmt.Fprintf(a.stderr, "error: %v\n", err)
 		}
 	}
+}
+
+func (a *App) runInteractiveLine(line string) error {
+	fields := strings.Fields(line)
+	if len(fields) == 0 {
+		return nil
+	}
+	if strings.HasPrefix(fields[0], "/") || isCommandName(fields[0]) {
+		return a.runCommand(fields)
+	}
+	return a.runChat(line)
 }
 
 func (a *App) runCommand(args []string) error {
@@ -92,8 +110,19 @@ func (a *App) runCommand(args []string) error {
 		return a.runModels(args[1:])
 	case "status":
 		return a.runStatus()
+	case "chat":
+		return a.runChat(strings.Join(args[1:], " "))
 	default:
 		return errUsage(fmt.Sprintf("unknown command %q", args[0]))
+	}
+}
+
+func isCommandName(command string) bool {
+	switch strings.TrimPrefix(strings.ToLower(command), "/") {
+	case "help", "-h", "--help", "connect", "models", "status", "chat":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -174,6 +203,45 @@ func (a *App) runStatus() error {
 	return nil
 }
 
+func (a *App) runChat(question string) error {
+	question = strings.TrimSpace(question)
+	if question == "" {
+		return errUsage("usage: dndx chat QUESTION")
+	}
+
+	config, err := loadConfig(a.configPath)
+	if err != nil {
+		return err
+	}
+
+	client, err := a.chatFactory(config)
+	if err != nil {
+		return err
+	}
+
+	userMessage := chatMessage{Role: "user", Content: question}
+	messages := append([]chatMessage{{Role: "system", Content: dndChatSystemPrompt}}, a.chatHistory...)
+	messages = append(messages, userMessage)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	fmt.Fprintln(a.stdout, "Thinking...")
+	answer, err := client.Send(ctx, messages)
+	if err != nil {
+		return err
+	}
+	answer = strings.TrimSpace(answer)
+	if answer == "" {
+		answer = emptyChatResponseMessage
+	}
+
+	a.chatHistory = append(a.chatHistory, userMessage, chatMessage{Role: "assistant", Content: answer})
+	fmt.Fprintln(a.stdout, answer)
+	fmt.Fprintln(a.stdout)
+	return nil
+}
+
 func (a *App) printHelp() {
 	fmt.Fprint(a.stdout, `dndx - DnDGenie command line companion
 
@@ -188,8 +256,12 @@ Commands:
   status
       Show the current provider, endpoint, and model configuration.
 
+  chat QUESTION
+      Send a question to the configured local chat model.
+
 Interactive:
-  Run dndx with no arguments to open a prompt. /quit exits.
+  Run dndx with no arguments to open a chat prompt. Type plain text to chat.
+  Slash commands such as /connect, /help, and /quit are handled locally.
 `)
 }
 

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +19,24 @@ func newTestApp(t *testing.T, stdin string) (*App, *bytes.Buffer, *bytes.Buffer,
 	stderr := &bytes.Buffer{}
 	app := NewApp(strings.NewReader(stdin), stdout, stderr, configPath)
 	return app, stdout, stderr, configPath
+}
+
+type fakeChatClient struct {
+	response string
+	messages []chatMessage
+	calls    int
+}
+
+func (f *fakeChatClient) Send(_ context.Context, messages []chatMessage) (string, error) {
+	f.calls++
+	f.messages = append([]chatMessage(nil), messages...)
+	return f.response, nil
+}
+
+type doerFunc func(req *http.Request) (*http.Response, error)
+
+func (f doerFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
 }
 
 func TestConnectLMStudioNormalizesBareEndpoint(t *testing.T) {
@@ -126,11 +148,105 @@ func TestInteractiveModeProcessesCommands(t *testing.T) {
 		t.Fatalf("config = %+v", config)
 	}
 	output := stdout.String()
-	if !strings.Contains(output, "dndx CLI") {
+	if !strings.Contains(output, "dndx chat") {
 		t.Fatalf("stdout missing banner: %s", output)
 	}
 	if !strings.Contains(output, "Provider: lmstudio") {
 		t.Fatalf("stdout missing status: %s", output)
+	}
+}
+
+func TestInteractiveModeSendsPlainTextToChat(t *testing.T) {
+	question := "provide a brief random encounter table for 3 first-level characters. They are in the woods."
+	app, stdout, stderr, configPath := newTestApp(t, question+"\n/quit\n")
+	if err := saveConfig(configPath, Config{
+		Provider:  providerLMStudio,
+		Endpoint:  defaultLMStudioEndpoint,
+		ChatModel: "glm-5.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeChatClient{response: "1. Three nervous scouts cross the trail."}
+	var factoryConfig Config
+	app.chatFactory = func(config Config) (chatClient, error) {
+		factoryConfig = config
+		return fake, nil
+	}
+
+	code := app.Run(nil)
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d: %s", code, stderr.String())
+	}
+	if fake.calls != 1 {
+		t.Fatalf("chat calls = %d", fake.calls)
+	}
+	if factoryConfig.ChatModel != "glm-5.0" {
+		t.Fatalf("factory config = %+v", factoryConfig)
+	}
+	if len(fake.messages) != 2 {
+		t.Fatalf("messages = %+v", fake.messages)
+	}
+	if fake.messages[0].Role != "system" {
+		t.Fatalf("first message = %+v", fake.messages[0])
+	}
+	if fake.messages[1].Role != "user" || fake.messages[1].Content != question {
+		t.Fatalf("user message = %+v", fake.messages[1])
+	}
+	output := stdout.String()
+	if !strings.Contains(output, interactivePrompt) {
+		t.Fatalf("stdout missing prompt: %s", output)
+	}
+	if !strings.Contains(output, "Thinking...") {
+		t.Fatalf("stdout missing thinking line: %s", output)
+	}
+	if !strings.Contains(output, "Three nervous scouts") {
+		t.Fatalf("stdout missing response: %s", output)
+	}
+}
+
+func TestDirectChatCommandSendsQuestion(t *testing.T) {
+	app, stdout, stderr, configPath := newTestApp(t, "")
+	if err := saveConfig(configPath, Config{
+		Provider:  providerLMStudio,
+		Endpoint:  defaultLMStudioEndpoint,
+		ChatModel: "glm-5.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeChatClient{response: "Roll 1d4 wolves."}
+	app.chatFactory = func(_ Config) (chatClient, error) {
+		return fake, nil
+	}
+
+	code := app.Run([]string{"chat", "provide", "a", "brief", "encounter"})
+
+	if code != 0 {
+		t.Fatalf("expected success, got %d: %s", code, stderr.String())
+	}
+	if fake.calls != 1 {
+		t.Fatalf("chat calls = %d", fake.calls)
+	}
+	if got := fake.messages[len(fake.messages)-1].Content; got != "provide a brief encounter" {
+		t.Fatalf("question = %q", got)
+	}
+	if !strings.Contains(stdout.String(), "Roll 1d4 wolves") {
+		t.Fatalf("stdout = %s", stdout.String())
+	}
+}
+
+func TestChatRequiresConfiguredEndpoint(t *testing.T) {
+	app, _, stderr, _ := newTestApp(t, "")
+
+	code := app.Run([]string{"chat", "hello"})
+
+	if code == 0 {
+		t.Fatal("expected failure")
+	}
+	if !strings.Contains(stderr.String(), "no model endpoint configured") {
+		t.Fatalf("stderr = %s", stderr.String())
 	}
 }
 
@@ -179,5 +295,101 @@ func TestSaveConfigCreatesPrivateConfigFile(t *testing.T) {
 	}
 	if info.Mode().Perm() != 0o600 {
 		t.Fatalf("mode = %v", info.Mode().Perm())
+	}
+}
+
+func TestOpenAIChatClientSendsChatCompletionRequest(t *testing.T) {
+	client := openAIChatClient{
+		endpoint: "http://lmstudio.test/v1/chat/completions",
+		model:    "glm-5.0",
+		doer: doerFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPost {
+				t.Fatalf("method = %s", req.Method)
+			}
+			if req.URL.Path != "/v1/chat/completions" {
+				t.Fatalf("path = %s", req.URL.Path)
+			}
+
+			var payload struct {
+				Model    string        `json:"model"`
+				Messages []chatMessage `json:"messages"`
+				Stream   bool          `json:"stream"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload.Model != "glm-5.0" {
+				t.Fatalf("model = %q", payload.Model)
+			}
+			if len(payload.Messages) != 1 || payload.Messages[0].Content != "encounter" {
+				t.Fatalf("messages = %+v", payload.Messages)
+			}
+			if payload.Stream {
+				t.Fatal("stream should be false")
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"choices":[{"message":{"role":"assistant","content":"Roll 1d4 wolves."}}]}`)),
+			}, nil
+		}),
+	}
+
+	answer, err := client.Send(context.Background(), []chatMessage{{Role: "user", Content: "encounter"}})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "Roll 1d4 wolves." {
+		t.Fatalf("answer = %q", answer)
+	}
+}
+
+func TestOllamaChatClientSendsNativeChatRequest(t *testing.T) {
+	client := ollamaChatClient{
+		endpoint: "http://ollama.test/api/chat",
+		model:    "llama3.2",
+		doer: doerFunc(func(req *http.Request) (*http.Response, error) {
+			if req.Method != http.MethodPost {
+				t.Fatalf("method = %s", req.Method)
+			}
+			if req.URL.Path != "/api/chat" {
+				t.Fatalf("path = %s", req.URL.Path)
+			}
+
+			var payload struct {
+				Model    string        `json:"model"`
+				Messages []chatMessage `json:"messages"`
+				Stream   bool          `json:"stream"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Fatal(err)
+			}
+			if payload.Model != "llama3.2" {
+				t.Fatalf("model = %q", payload.Model)
+			}
+			if len(payload.Messages) != 1 || payload.Messages[0].Content != "encounter" {
+				t.Fatalf("messages = %+v", payload.Messages)
+			}
+			if payload.Stream {
+				t.Fatal("stream should be false")
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"message":{"role":"assistant","content":"Use two scouts and a lost map."}}`)),
+			}, nil
+		}),
+	}
+
+	answer, err := client.Send(context.Background(), []chatMessage{{Role: "user", Content: "encounter"}})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if answer != "Use two scouts and a lost map." {
+		t.Fatalf("answer = %q", answer)
 	}
 }

--- a/cli/chat.go
+++ b/cli/chat.go
@@ -1,0 +1,154 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	dndChatSystemPrompt      = "You are DnDGenie, a concise tabletop RPG assistant. Help the user prepare and run Dungeons & Dragons at the table. Prefer practical, table-ready answers."
+	emptyChatResponseMessage = "The chat model returned an empty answer. Try a different chat model, or confirm the model is loaded in your local model server."
+	defaultChatMaxTokens     = 2048
+)
+
+type chatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type chatClient interface {
+	Send(ctx context.Context, messages []chatMessage) (string, error)
+}
+
+type chatClientFactory func(config Config) (chatClient, error)
+
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type openAIChatClient struct {
+	endpoint string
+	model    string
+	doer     httpDoer
+}
+
+type ollamaChatClient struct {
+	endpoint string
+	model    string
+	doer     httpDoer
+}
+
+func newChatClient(config Config) (chatClient, error) {
+	if config.Provider == "" || config.Endpoint == "" {
+		return nil, errUsage("no model endpoint configured; run /connect lmstudio first")
+	}
+	if config.ChatModel == "" {
+		return nil, errUsage("no chat model configured; run models --chat MODEL first")
+	}
+
+	doer := &http.Client{Timeout: 5 * time.Minute}
+	switch config.Provider {
+	case providerLMStudio:
+		return openAIChatClient{
+			endpoint: strings.TrimRight(config.Endpoint, "/") + "/chat/completions",
+			model:    config.ChatModel,
+			doer:     doer,
+		}, nil
+	case providerOllama:
+		return ollamaChatClient{
+			endpoint: strings.TrimRight(config.Endpoint, "/") + "/api/chat",
+			model:    config.ChatModel,
+			doer:     doer,
+		}, nil
+	default:
+		return nil, errUsage("provider must be lmstudio or ollama")
+	}
+}
+
+func (c openAIChatClient) Send(ctx context.Context, messages []chatMessage) (string, error) {
+	requestBody := struct {
+		Model       string        `json:"model"`
+		Messages    []chatMessage `json:"messages"`
+		Stream      bool          `json:"stream"`
+		Temperature float64       `json:"temperature"`
+		MaxTokens   int           `json:"max_tokens"`
+	}{
+		Model:       c.model,
+		Messages:    messages,
+		Stream:      false,
+		Temperature: 0.4,
+		MaxTokens:   defaultChatMaxTokens,
+	}
+
+	var responseBody struct {
+		Choices []struct {
+			Message chatMessage `json:"message"`
+		} `json:"choices"`
+	}
+	if err := postJSON(ctx, c.doer, c.endpoint, requestBody, &responseBody); err != nil {
+		return "", err
+	}
+	if len(responseBody.Choices) == 0 {
+		return "", nil
+	}
+	return responseBody.Choices[0].Message.Content, nil
+}
+
+func (c ollamaChatClient) Send(ctx context.Context, messages []chatMessage) (string, error) {
+	requestBody := struct {
+		Model    string        `json:"model"`
+		Messages []chatMessage `json:"messages"`
+		Stream   bool          `json:"stream"`
+	}{
+		Model:    c.model,
+		Messages: messages,
+		Stream:   false,
+	}
+
+	var responseBody struct {
+		Message chatMessage `json:"message"`
+	}
+	if err := postJSON(ctx, c.doer, c.endpoint, requestBody, &responseBody); err != nil {
+		return "", err
+	}
+	return responseBody.Message.Content, nil
+}
+
+func postJSON(ctx context.Context, doer httpDoer, endpoint string, requestBody any, responseBody any) error {
+	payload, err := json.Marshal(requestBody)
+	if err != nil {
+		return err
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Authorization", "Bearer lm-studio")
+
+	response, err := doer.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+
+	data, err := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if response.StatusCode < 200 || response.StatusCode > 299 {
+		return fmt.Errorf("chat request failed with HTTP %d: %s", response.StatusCode, strings.TrimSpace(string(data)))
+	}
+
+	if err := json.Unmarshal(data, responseBody); err != nil {
+		return fmt.Errorf("decode chat response: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- send plain text from the dndx interactive prompt to the configured local chat model
- add one-off dndx chat QUESTION support
- support LM Studio /v1/chat/completions and Ollama /api/chat
- document the new _ chat prompt and add unit coverage for chat requests

## Tests
- env GOCACHE=/private/tmp/dndx-go-cache go test ./...
- live LM Studio smoke test against http://127.0.0.1:1234 using glm-5.0