### PR TITLE
Make dndx prompt underscore blink

### DIFF
--- a/cli/app.go
+++ b/cli/app.go
@@ -10,7 +10,11 @@ import (
 	"time"
 )
 
-const interactivePrompt = "dndx _ "
+const (
+	ansiBlink         = "\x1b[5m"
+	ansiReset         = "\x1b[0m"
+	interactivePrompt = "dndx " + ansiBlink + "_" + ansiReset + " "
+)
 
 type App struct {
 	stdin       io.Reader

--- a/cli/app_test.go
+++ b/cli/app_test.go
@@ -156,6 +156,15 @@ func TestInteractiveModeProcessesCommands(t *testing.T) {
 	}
 }
 
+func TestInteractivePromptBlinksUnderscore(t *testing.T) {
+	if !strings.Contains(interactivePrompt, ansiBlink+"_") {
+		t.Fatalf("prompt should blink underscore: %q", interactivePrompt)
+	}
+	if !strings.Contains(interactivePrompt, "_"+ansiReset) {
+		t.Fatalf("prompt should reset after underscore: %q", interactivePrompt)
+	}
+}
+
 func TestInteractiveModeSendsPlainTextToChat(t *testing.T) {
 	question := "provide a brief random encounter table for 3 first-level characters. They are in the woods."
 	app, stdout, stderr, configPath := newTestApp(t, question+"\n/quit\n")


### PR DESCRIPTION
## Summary
- wrap the interactive dndx prompt underscore in ANSI blink/reset escape codes
- add a regression test so the prompt keeps the blinking underscore behavior

## Tests
- env GOCACHE=/private/tmp/dndx-go-cache go test ./...