### PR TITLE
Lightly refactor how we determine the config file path

### DIFF
--- a/cli/config.go
+++ b/cli/config.go
@@ -33,7 +33,7 @@ func configPathFromEnv() string {
 	}
 
 	if d, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(d, "dndx", "config.json")
+		return filepath.Join(d, ".dndx", "config.json")
 	}
 
 	return "dndx.json"

--- a/cli/config.go
+++ b/cli/config.go
@@ -28,12 +28,12 @@ func configPathFromEnv() string {
 		return configured
 	}
 
-	if configDir, err := os.UserConfigDir(); err == nil {
-		return filepath.Join(configDir, "dndx", "config.json")
+	if d, err := os.UserConfigDir(); err == nil {
+		return filepath.Join(d, "dndx", "config.json")
 	}
 
-	if homeDir, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(homeDir, ".config", "dndx", "config.json")
+	if d, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(d, "dndx", "config.json")
 	}
 
 	return "dndx.json"

--- a/cli/config.go
+++ b/cli/config.go
@@ -28,16 +28,15 @@ func configPathFromEnv() string {
 		return configured
 	}
 
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		homeDir, homeErr := os.UserHomeDir()
-		if homeErr != nil {
-			return "dndx.json"
-		}
-		configDir = filepath.Join(homeDir, ".config")
+	if configDir, err := os.UserConfigDir(); err == nil {
+		return filepath.Join(configDir, "dndx", "config.json")
 	}
 
-	return filepath.Join(configDir, "dndx", "config.json")
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(homeDir, ".config", "dndx", "config.json")
+	}
+
+	return "dndx.json"
 }
 
 func loadConfig(path string) (Config, error) {


### PR DESCRIPTION
Lightly refactor `main#configPathFromEnv()` to de-nest an if-slide.

On setups that can't answer `file.UserConfigDir()`, we previously defaulted to `$HOME/dndx/config.json`. Now we will default to `$HOME/.dndx/config.json` (note the `.dndx`).
